### PR TITLE
fix(init.lua): attempt to index field 'opts' (a nil value)

### DIFF
--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -208,7 +208,7 @@ function db:load_theme(opts)
   api.nvim_buf_set_name(self.bufnr, utils.gen_bufname(opts.buffer_name))
 
   if #opts.preview.command > 0 then
-    config = vim.tbl_extend('force', config, self.opts.preview)
+    config = vim.tbl_extend('force', config, opts.preview)
   end
 
   require('dashboard.theme.' .. opts.theme)(config)


### PR DESCRIPTION
It's an error when applying 'Dashboard' in opened buffer:
```vim
Error executing vim.schedule lua callback: ...al/share/nvim/lazy/dashboard-nvim/lua/dashboard/init.lua:213: attempt to index field 'opts' (a nil value)
stack traceback:
        ...al/share/nvim/lazy/dashboard-nvim/lua/dashboard/init.lua:213: in function 'load_theme'
        ...al/share/nvim/lazy/dashboard-nvim/lua/dashboard/init.lua:273: in function 'callback'
        ...al/share/nvim/lazy/dashboard-nvim/lua/dashboard/init.lua:192: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>

```