### PR TITLE
Trailing null char (`\0`) in cache leading to crash

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -108,6 +108,7 @@ local function project_list(config, callback)
 
   local function read_project(data)
     local res = {}
+    data = string.gsub(data, '%z', '')
     local dump = assert(loadstring(data))
     local list = dump()
     if list then


### PR DESCRIPTION
Stacktrace:
<img width="1662" alt="image" src="https://github.com/nvimdev/dashboard-nvim/assets/1140383/2a80c960-232a-4668-ab86-b0ce90154c2d">


The paths string from cache looks like below somehow
```
"return { \"/Users/username/lexical/projects/lexical_plugin\", \"/Users/username/lexical/apps/protocol\", \"/Users/username/lexical\
", \"/Users/username/lexical/projects/lexical_shared\", \"/Users/username/dotfiles\" }\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0
\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
```

I recently upgraded to `MacOS Ventura 13.4`, not sure if it's related tho. Also don't find any thing fishy in the `project_delete` function. Hence, do some clean up before `loadstring` of the data.