### PR TITLE
Feat: added additional plugins info when using lazy.nvim

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -153,7 +153,25 @@ end
 
 local function generate_footer(config)
   local first_line = api.nvim_buf_line_count(config.bufnr)
-  local footer = { '', '', 'neovim loaded ' .. utils.get_packages_count() .. ' packages' }
+  local package_manager_stats = utils.get_package_manager_stats()
+  local footer = {}
+  if package_manager_stats.name == 'lazy' then
+    footer = {
+      '',
+      '',
+      'Startuptime: ' .. package_manager_stats.time .. ' ms',
+      'Plugins: '
+        .. package_manager_stats.loaded
+        .. ' loaded / '
+        .. package_manager_stats.count
+        .. ' installed',
+    }
+  else
+    footer = {
+      '',
+      'neovim loaded ' .. package_manager_stats.count .. ' plugins',
+    }
+  end
   if config.footer then
     if type(config.footer) == 'function' then
       footer = config.footer()

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -77,10 +77,24 @@ local function load_packages(config)
     return
   end
 
-  local lines = {
-    '',
-    'neovim loaded ' .. utils.get_packages_count() .. ' packages',
-  }
+  local package_manager_stats = utils.get_package_manager_stats()
+  local lines = {}
+  if package_manager_stats.name == 'lazy' then
+    lines = {
+      '',
+      'Startuptime: ' .. package_manager_stats.time .. ' ms',
+      'Plugins: '
+        .. package_manager_stats.loaded
+        .. ' loaded / '
+        .. package_manager_stats.count
+        .. ' installed',
+    }
+  else
+    lines = {
+      '',
+      'neovim loaded ' .. package_manager_stats.count .. ' plugins',
+    }
+  end
 
   local first_line = api.nvim_buf_line_count(config.bufnr)
   api.nvim_buf_set_lines(config.bufnr, first_line, -1, false, utils.center_align(lines))

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -112,18 +112,22 @@ function utils.get_mru_list()
   return mru
 end
 
-function utils.get_packages_count()
-  local count = 0
+function utils.get_package_manager_stats()
+  local package_manager_stats = { name = '', count = 0, loaded = 0, time = 0 }
   ---@diagnostic disable-next-line: undefined-global
   if packer_plugins then
+    package_manager_stats.name = 'packer'
     ---@diagnostic disable-next-line: undefined-global
-    count = #vim.tbl_keys(packer_plugins)
+    package_manager_stats.count = #vim.tbl_keys(packer_plugins)
   end
   local status, lazy = pcall(require, 'lazy')
   if status then
-    count = lazy.stats().count
+    package_manager_stats.name = 'lazy'
+    package_manager_stats.loaded = lazy.stats().loaded
+    package_manager_stats.count = lazy.stats().count
+    package_manager_stats.time = lazy.stats().startuptime
   end
-  return count
+  return package_manager_stats
 end
 
 --- generate an empty table by length


### PR DESCRIPTION
This PR adds additional info to the dashboard when using lazy.nvim

Added:
- Startuptime
- Number of plugins loaded vs total

Thoughts:
- Could we display similar info when using packer.nvim?
- Display `Startuptime` only when displaying Dashboard at startup?

Let me know what you think.

![image](https://github.com/nvimdev/dashboard-nvim/assets/33832653/e1f64c42-4f46-4610-a763-7de0a49fb89a)