### PR TITLE
fix: checks if current buffer = config.bufnr before creating autocmd

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -114,6 +114,9 @@ local function generate_center(config)
   local bottom = api.nvim_buf_line_count(config.bufnr)
   vim.defer_fn(function()
     local before = 0
+    if api.nvim_get_current_buf() ~= config.bufnr then
+      return
+    end
     api.nvim_create_autocmd('CursorMoved', {
       buffer = config.bufnr,
       callback = function()


### PR DESCRIPTION
I use [auto-session](https://github.com/rmagatti/auto-session) to restore previous session.  If I execute restore too quickly after dashboard is displayed it will produce error like in #364 and #339. 

PR checks bufnr before creating autocmd, which is using the nonexistent buffer id of 1 producing the error.

