### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ use {
 
 ```lua
 theme = 'hyper' --  theme is doom and hyper default is hyper
-disable_move    --  default is false disable move keymap for hyper
 shortcut_type   --  shorcut type 'letter' or 'number'
 change_to_vcs_root -- default is false,for open file in hyper mru. it will change to the root of vcs
 config = {},    --  config used for theme


### PR DESCRIPTION
`disable_move` is useless when it's outside of the config of the theme.
It maybe out-of-date.