### PR TITLE
fix: display devicons properly

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -173,8 +173,8 @@ local function mru_list(config)
   local mlist = utils.get_mru_list()
 
   for _, file in pairs(vim.list_slice(mlist, 1, config.mru.limit)) do
-    local ft = vim.filetype.match({ filename = file })
-    local icon, group = utils.get_icon(ft)
+    local filename = vim.fn.fnamemodify(file, ':t')
+    local icon, group = utils.get_icon(filename)
     icon = icon or ' '
     if not utils.is_win then
       file = file:gsub(vim.env.HOME, '~')

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -61,13 +61,13 @@ function utils.center_align(tbl)
   return centered_lines
 end
 
-function utils.get_icon(ft)
+function utils.get_icon(filename)
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if not ok then
     vim.notify('[dashboard.nvim] not found nvim-web-devicons')
     return nil
   end
-  return devicons.get_icon_by_filetype(ft, { default = true })
+  return devicons.get_icon(filename, nil, { default = true })
 end
 
 function utils.read_project_cache(path)


### PR DESCRIPTION
there seems to be a problem with displaying some of the devicons, especially overrides with multidot extensions like `.module.ts`, this makes sure the proper mechanism of `nvim-web-devicons` is utilized to retrieve the longest matching extension from the filename

before
![before](https://github.com/nvimdev/dashboard-nvim/assets/145394295/359ba72e-2779-491f-946e-a82a986fcc8c)

after
![after](https://github.com/nvimdev/dashboard-nvim/assets/145394295/7504b5da-5b40-463a-adba-53841bc18a44)
