### PR TITLE
Add uppercase letters for hotkey generation

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -207,6 +207,8 @@ local function letter_hotkey(config)
     end
   end
 
+  math.randomseed(os.time())
+
   -- Create key table, fill it with unused characters.
   local unused_keys = {}
   -- a - z
@@ -215,18 +217,23 @@ local function letter_hotkey(config)
       table.insert(unused_keys, key)
     end
   end
-  -- TODO: Allow generation of upper case characters?
-  --       Maybe upper characters could be used only after all lowercase ones are exhausted?
-  -- A - Z
-  -- for key = 65, 90 do
-  --   if not vim.tbl_contains(list, key) then
-  --     table.insert(unused_keys, key)
-  --   end
-  -- end
 
-  -- Shuffle the unused_keys table.
-  math.randomseed(os.time())
   shuffle_table(unused_keys)
+
+  local unused_uppercase_keys = {}
+  -- A - Z
+  for key = 65, 90 do
+    if not vim.tbl_contains(list, key) then
+      table.insert(unused_uppercase_keys, key)
+    end
+  end
+
+  shuffle_table(unused_uppercase_keys)
+
+  -- Push shuffled uppercase keys after the lowercase ones
+  for _, key in pairs(unused_uppercase_keys) do
+    table.insert(unused_keys, key)
+  end
 
   local fallback_hotkey = 0
 


### PR DESCRIPTION
Currently, after all letters are exhausted, the hotkey generation falls back to generation numbers.
![image](https://github.com/nvimdev/dashboard-nvim/assets/59198958/06a16261-c121-4859-b2de-2f9f4e1b2460)

This commit changes it slightly, so that the uppercase keys generate after the lowercase ones:
![image](https://github.com/nvimdev/dashboard-nvim/assets/59198958/e3eb70b2-6913-4a97-b4fc-128614423dee)

Before the hotkey generation change there was no uppercase keys and that's why I put it as TODO in the #382 commit.

If you like this change go ahead and merge the it and if you don't, feel free to close it and remove the original TODO from the generate_letter function :)