### PR TITLE
feat(doom): configurable key_format property

### DIFF
--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -135,6 +135,7 @@ when use `doom` theme the available options in `config` is
           desc_hl = 'group',
           key = 'shortcut key in dashboard buffer not keymap !!',
           key_hl = 'group',
+          key_format = ' [%s]', -- `%s` will be substituted with value of `key`
           action = '',
         },
       },
@@ -224,6 +225,7 @@ Doom ~
             key = 'b',
             keymap = 'SPC f f',
             key_hl = 'Number',
+            key_format = ' %s', -- remove default surrounding `[]`
             action = 'lua print(2)'
           },
           {
@@ -231,6 +233,7 @@ Doom ~
             desc = 'Find Dotfiles',
             key = 'f',
             keymap = 'SPC f d',
+            key_format = ' %s', -- remove default surrounding `[]`
             action = 'lua print(3)'
           },
         },

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -94,10 +94,10 @@ local function generate_center(config)
         if config.center[idx].keymap then
           table.insert(virt_tbl, { config.center[idx].keymap, 'DashboardShortCut' })
         end
-        table.insert(
-          virt_tbl,
-          { ' [' .. config.center[idx].key .. ']', config.center[idx].key_hl or 'DashboardKey' }
-        )
+        table.insert(virt_tbl, {
+          string.format(config.center[idx].key_format or ' [%s]', config.center[idx].key),
+          config.center[idx].key_hl or 'DashboardKey',
+        })
         api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i - 1, 0, {
           virt_text_pos = 'eol',
           virt_text = virt_tbl,


### PR DESCRIPTION
This makes the `key` value format configurable for the `doom` theme through the `key_format` property. E.g. use case included in docs.


Thought about putting the config prop at a higher level so the same format is applied to all, but decided on the per-item config because it's more consistent and flexible.