### PR TITLE
chore(doom): add key_format config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ config = {
       desc_hl = 'group',
       key = 'shortcut key in dashboard buffer not keymap !!',
       key_hl = 'group',
+      key_format = ' [%s]', -- `%s` will be substituted with value of `key`
       action = '',
     },
   },
@@ -205,6 +206,7 @@ db.setup({
         key = 'b',
         keymap = 'SPC f f',
         key_hl = 'Number',
+        key_format = ' %s', -- remove default surrounding `[]`
         action = 'lua print(2)'
       },
       {
@@ -212,6 +214,7 @@ db.setup({
         desc = 'Find Dotfiles',
         key = 'f',
         keymap = 'SPC f d',
+        key_format = ' %s', -- remove default surrounding `[]`
         action = 'lua print(3)'
       },
     },


### PR DESCRIPTION
So yesterday when I submitted the `key_format` change I'd updated `doc/dashboard.txt` directly without realizing that was auto-generated from `README.md` by gh action (I thought it was the other way around). So obviously my doc changes got overridden :P.

This should correct that.