### PR TITLE
Implement dashboard entering / leaving callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ db.setup({
   }
 })
 ```
-</details
+</details>
 
 ### Changed
 
@@ -234,6 +234,24 @@ db.setup({
 
 - I will write a plugin to implement some popular terminal evaluators image protocol then I think
   can make it work with dashboard
+
+## Callbacks
+
+use `setup_callbacks` to setup functions called on entering / leaving dashboard
+
+```lua
+require('dashboard').setup {
+  -- config
+}
+require('dashboard').setup_callbacks({
+  enter = function()
+    -- called on entering dashboard
+  end,
+  leave = function()
+    -- called on leaving dashboard
+  end,
+})
+```
 
 # Backers
 

--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -8,6 +8,7 @@ Table of Contents                                *dashboard-table-of-contents*
 3. Configuration                                     |dashboard-configuration|
   - Options                                  |dashboard-configuration-options|
   - Theme config                        |dashboard-configuration-theme-config|
+  - Callbacks                              |dashboard-configuration-callbacks|
 4. Backers                                                 |dashboard-backers|
 5. Donate                                                   |dashboard-donate|
 6. LICENSE                                                 |dashboard-license|
@@ -257,6 +258,24 @@ TODO ~
 - I will write a plugin to implement some popular terminal evaluators image protocol then I think
     can make it work with dashboard
 
+
+CALLBACKS                                  *dashboard-configuration-callbacks*
+
+use `setup_callbacks` to setup functions called on entering / leaving dashboard
+
+>lua
+    require('dashboard').setup {
+      -- config
+    }
+    require('dashboard').setup_callbacks({
+      enter = function()
+        -- called on entering dashboard
+      end,
+      leave = function()
+        -- called on leaving dashboard
+      end,
+    })
+<
 
 ==============================================================================
 4. Backers                                                 *dashboard-backers*

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -2,6 +2,7 @@ local api, fn = vim.api, vim.fn
 local utils = require('dashboard.utils')
 local ctx = {}
 local db = {}
+local callbacks = {}
 
 db.__index = db
 db.__newindex = function(t, k, v)
@@ -196,6 +197,9 @@ function db:get_opts(callback)
 end
 
 function db:load_theme(opts)
+  if callbacks.enter then
+    callbacks.enter()
+  end
   local config = vim.tbl_extend('force', opts.config, {
     path = cache_path(),
     bufnr = self.bufnr,
@@ -231,6 +235,9 @@ function db:load_theme(opts)
         self:restore_options()
         clean_ctx()
         pcall(api.nvim_del_autocmd, opt.id)
+        if callbacks.leave then
+          callbacks.leave()
+        end
       end
     end,
     desc = '[Dashboard] clean dashboard data reduce memory',
@@ -273,6 +280,10 @@ end
 function db.setup(opts)
   opts = opts or {}
   ctx.opts = vim.tbl_deep_extend('force', default_options(), opts)
+end
+
+function db.setup_callbacks(opts)
+  callbacks = opts
 end
 
 return setmetatable(ctx, db)


### PR DESCRIPTION
# Why

I use `indent-blankline.nvim` plugin for indent display but the indent lines are shown on dashboard as below

![indent_blankline_issue_in_dashboard](https://github.com/nvimdev/dashboard-nvim/assets/2861357/e850be78-d7e8-4cdf-99f0-b9ad64e07e69)

To fix it, I need disable  `indent-blankline.nvim` plugin when entering dashboard and enable it when leaving dashboard. Here is the fixed result.

![fixed_with_callbacks](https://github.com/nvimdev/dashboard-nvim/assets/2861357/ba9389dd-a3fa-40a7-92f8-058e57c7b3f0)

# Uasge

Use `setup_callbacks` to setup functions called on entering / leaving dashboard

```lua
		require("dashboard").setup({
			-- configs
		})
		require("dashboard").setup_callbacks({
			enter = function()
				-- called on entering dashboard
				vim.cmd("IBLDisable")
			end,
			leave = function()
				-- called on leaving dashboard
				vim.cmd("IBLEnable")
			end,
		})

``` 

# Implementation

- The entering callback is called at the beginning of `db:load_theme`. 
- The leaving callback is called at `BufEnter` autocmd after dashboard clean up.

It seems to work well but I am not sure it is the best way to do. Any discussion and modification are welcome.
