### PR TITLE
feat(hyper): option to limit mru list to cwd

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+    "workspace.library": [
+        "/Users/jack/.local/share/nvim/lazy/neodev.nvim/types/nightly",
+        "/opt/homebrew/Cellar/neovim/HEAD-4c32927/share/nvim/runtime/lua",
+        "/Users/jack/dev/nvim-plugins/dashboard-nvim/lua",
+        "${3rd}/luv/library"
+    ]
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,8 +1,0 @@
-{
-    "workspace.library": [
-        "/Users/jack/.local/share/nvim/lazy/neodev.nvim/types/nightly",
-        "/opt/homebrew/Cellar/neovim/HEAD-4c32927/share/nvim/runtime/lua",
-        "/Users/jack/dev/nvim-plugins/dashboard-nvim/lua",
-        "${3rd}/luv/library"
-    ]
-}

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ config = {
   -- action can be a functino type, e.g.
   -- action = func(path) vim.cmd('Telescope find_files cwd=' .. path) end
   project = { enable = true, limit = 8, icon = 'your icon', label = '', action = 'Telescope find_files cwd=' },
-  mru = { limit = 10, icon = 'your icon', label = '', },
+  mru = { limit = 10, icon = 'your icon', label = '', cwd_only = false },
   footer = {}, -- footer
 }
 ```

--- a/doc/dashboard.txt
+++ b/doc/dashboard.txt
@@ -115,7 +115,7 @@ when use `hyper` theme the available options in `config` is
       -- action can be a functino type, e.g.
       -- action = func(path) vim.cmd('Telescope find_files cwd=' .. path) end
       project = { enable = true, limit = 8, icon = 'your icon', label = '', action = 'Telescope find_files cwd=' },
-      mru = { limit = 10, icon = 'your icon', label = '', },
+      mru = { limit = 10, icon = 'your icon', label = '', cwd_only = false },
       footer = {}, -- footer
     }
 <

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -163,6 +163,7 @@ local function mru_list(config)
     limit = 10,
     icon_hl = 'DashboardMruIcon',
     label = ' Most Recent Files:',
+    cwd_only = false,
   }, config.mru or {})
 
   local list = {
@@ -171,6 +172,16 @@ local function mru_list(config)
 
   local groups = {}
   local mlist = utils.get_mru_list()
+
+  if config.mru.cwd_only then
+    local cwd = vim.fn.getcwd()
+    mlist = vim.tbl_filter(function(file)
+      local file_dir = vim.fn.fnamemodify(file, ':p:h')
+      if file_dir and cwd then
+        return file_dir:find(cwd, 1, true) == 1
+      end
+    end, mlist)
+  end
 
   for _, file in pairs(vim.list_slice(mlist, 1, config.mru.limit)) do
     local filename = vim.fn.fnamemodify(file, ':t')

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -1,4 +1,4 @@
-local api, keymap = vim.api, vim.keymap
+local api, keymap, uv = vim.api, vim.keymap, vim.loop
 local utils = require('dashboard.utils')
 local ns = api.nvim_create_namespace('dashboard')
 
@@ -174,7 +174,7 @@ local function mru_list(config)
   local mlist = utils.get_mru_list()
 
   if config.mru.cwd_only then
-    local cwd = vim.fn.getcwd()
+    local cwd = uv.cwd()
     mlist = vim.tbl_filter(function(file)
       local file_dir = vim.fn.fnamemodify(file, ':p:h')
       if file_dir and cwd then


### PR DESCRIPTION
This adds a new `cwd_only` option to limit the Most Recent File list to the `cwd`, defaulted to `false` to preserve current plugin behaviour.