### PR TITLE
Fix position of preview window

### DIFF
--- a/lua/dashboard/preview.lua
+++ b/lua/dashboard/preview.lua
@@ -133,6 +133,7 @@ function view:open_preview(opt)
   })
 
   self:preview_events()
+  return self.preview_bufnr, self.preview_winid
 end
 
 return view

--- a/lua/dashboard/theme/header.lua
+++ b/lua/dashboard/theme/header.lua
@@ -123,7 +123,7 @@ local function generate_header(config)
   local empty_table = utils.generate_empty_table(config.file_height + 4)
   api.nvim_buf_set_lines(config.bufnr, 0, -1, false, utils.center_align(empty_table))
   local preview = require('dashboard.preview')
-  preview:open_preview({
+  return preview:open_preview({
     width = config.file_width,
     height = config.file_height,
     cmd = config.command .. ' ' .. config.file_path,

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -485,7 +485,7 @@ local function theme_instance(config)
     if config.disable_move then
       utils.disable_move_key(config.bufnr)
     end
-    require('dashboard.theme.header').generate_header(config)
+    local _, preview_winid = require('dashboard.theme.header').generate_header(config)
     gen_shortcut(config)
     load_packages(config)
     gen_center(plist, config)
@@ -499,6 +499,14 @@ local function theme_instance(config)
     api.nvim_buf_set_lines(config.bufnr, 0, 0, false, fill)
     vim.bo[config.bufnr].modifiable = false
     vim.bo[config.bufnr].modified = false
+
+    -- re-set the position of preview window with top padding = size
+    if preview_winid then
+      local winconfig = api.nvim_win_get_config(preview_winid)
+      winconfig.row = size + 2
+      api.nvim_win_set_config(preview_winid, winconfig)
+    end
+
     --defer until next event loop
     vim.schedule(function()
       api.nvim_exec_autocmds('User', {


### PR DESCRIPTION
When using the `hyper` theme with preview config, the logo is shown by the preview command on the preview window is always on the top of the screen. I think the problem is on line `7` of file `lua/dashboard/preview.lua`:
```lua
   local row = math.floor(opt.height / 5)
```
The position of the preview window seems to be fixed.
So my solution is updating the position `row` of the preview window after rendering all components
In `lua/dashboard/theme/hyper.lua`, line 495. I found:
```lua
  local size = math.floor(vim.o.lines / 2)
      - math.ceil(api.nvim_buf_line_count(config.bufnr) / 2)
      - 2
  local fill = utils.generate_empty_table(size)
```

So I set the value for the `row` attribute to size to make the preview window to be on the right position as the normal logo(header)

PS: Forgive my poor English.

<img width="1133" alt="image" src="https://github.com/nvimdev/dashboard-nvim/assets/75310135/7695c95a-8751-4aea-976a-f68c17b8510f">
