### PR TITLE
fix(doom): Adjust cursor position for multibyte charsets in menu entry

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -133,7 +133,7 @@ local function generate_center(config)
         -- FIX: #422: In Lua the length of a string is the numbers of bytes not
         -- the number of characters.
         local curline_str = api.nvim_buf_get_lines(config.bufnr, curline - 1, curline, false)[1]
-        local delta = curline_str:len() - vim.api.nvim_strwidth(curline_str) - 2
+        local delta = curline_str:len() - api.nvim_strwidth(curline_str) - 2
         api.nvim_win_set_cursor(config.winid, { curline, col + delta })
       end,
     })

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -129,7 +129,12 @@ local function generate_center(config)
           curline = curline + (before > curline and -1 or 1)
         end
         before = curline
-        api.nvim_win_set_cursor(config.winid, { curline, col })
+
+        -- FIX: #422: In Lua the length of a string is the numbers of bytes not
+        -- the number of characters.
+        local curline_str = api.nvim_buf_get_lines(config.bufnr, curline - 1, curline, false)[1]
+        local delta = curline_str:len() - vim.api.nvim_strwidth(curline_str) - 2
+        api.nvim_win_set_cursor(config.winid, { curline, col + delta })
       end,
     })
   end, 0)


### PR DESCRIPTION
This should fix #422. There is a problem with multibyte charsets (like some nerd-fonts icons), cause Lua count the bytes and not the chars of a string (At least with [Lua 5.2](https://www.lua.org/manual/5.2/manual.html#2.1)). In this case, even if `col` is the correct position, its not counting the extra byte of the icon character.

This PR adds a `delta` value that would insert an offset to the `col` value when needed.

Regards