### PR TITLE
fix(doom): Fix cursor position for menu entries with other than 2 chars

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -108,6 +108,7 @@ local function generate_center(config)
 
   local line = api.nvim_buf_get_lines(config.bufnr, first_line, first_line + 1, false)[1]
   local col = line:find('%w')
+  local col_width = api.nvim_strwidth(line:sub(1, col))
   col = col and col - 1 or 9999
   api.nvim_win_set_cursor(config.winid, { first_line + 1, col })
 
@@ -133,7 +134,7 @@ local function generate_center(config)
         -- FIX: #422: In Lua the length of a string is the numbers of bytes not
         -- the number of characters.
         local curline_str = api.nvim_buf_get_lines(config.bufnr, curline - 1, curline, false)[1]
-        local delta = curline_str:len() - api.nvim_strwidth(curline_str) - 2
+        local delta = col_width - api.nvim_strwidth(curline_str:sub(1, col + 1))
         api.nvim_win_set_cursor(config.winid, { curline, col + delta })
       end,
     })


### PR DESCRIPTION
This should be a better approach than my previous PR (#424). The problem was that if icon strings with other than two characters where used, the cursor would be incorrectly positioned. Now it works when the user has no icons or uses widths other than two characters (`"c "`). For example: `"c"`, `"c "`, `"c "`, etc.

Regards