### PR TITLE
docs(doom): Add descriptions to autogenerated keymaps

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -1,4 +1,4 @@
-local api = vim.api
+local api, keymap = vim.api, vim.keymap
 local utils = require('dashboard.utils')
 
 local function generate_center(config)
@@ -16,23 +16,18 @@ local function generate_center(config)
     if item.key then
       line = line .. (' '):rep(#item.key + 4)
       count = count + #item.key + 3
-      if type(item.action) == 'string' then
-        vim.keymap.set('n', item.key, function()
+      keymap.set('n', item.key, function()
+        if type(item.action) == 'string' then
           local dump = loadstring(item.action)
           if not dump then
             vim.cmd(item.action)
           else
             dump()
           end
-        end, { buffer = config.bufnr, nowait = true, silent = true })
-      elseif type(item.action) == 'function' then
-        vim.keymap.set(
-          'n',
-          item.key,
-          item.action,
-          { buffer = config.bufnr, nowait = true, silent = true }
-        )
-      end
+        elseif type(item.action) == 'function' then
+          item.action()
+        end
+      end, { buffer = config.bufnr, nowait = true, silent = true })
     end
 
     if item.keymap then
@@ -140,7 +135,7 @@ local function generate_center(config)
     })
   end, 0)
 
-  vim.keymap.set('n', config.confirm_key or '<CR>', function()
+  keymap.set('n', config.confirm_key or '<CR>', function()
     local curline = api.nvim_win_get_cursor(0)[1]
     local index = pos_map[curline - first_line]
     if index and config.center[index].action then

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -16,6 +16,7 @@ local function generate_center(config)
     if item.key then
       line = line .. (' '):rep(#item.key + 4)
       count = count + #item.key + 3
+      local desc = 'Dashboard-action: ' .. item.desc:gsub('^%s+', '')
       keymap.set('n', item.key, function()
         if type(item.action) == 'string' then
           local dump = loadstring(item.action)
@@ -27,7 +28,7 @@ local function generate_center(config)
         elseif type(item.action) == 'function' then
           item.action()
         end
-      end, { buffer = config.bufnr, nowait = true, silent = true })
+      end, { buffer = config.bufnr, nowait = true, silent = true, desc = desc })
     end
 
     if item.keymap then


### PR DESCRIPTION
This PR refactors the `keymap.set` call in the Doom theme, aligning it with the code from Hyper and incorporating descriptions from `entry.desc` into the `opts` table of the `keymap.set` function. So, when users explore their keymaps values, such as in the `:Telescope keymaps` picker, they will see meaningful descriptions instead of `<anonymous>`.