### PR TITLE
bugfix: make sure current buffer is dashboard

### DIFF
--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -117,6 +117,11 @@ local function generate_center(config)
     api.nvim_create_autocmd('CursorMoved', {
       buffer = config.bufnr,
       callback = function()
+        local buf = api.nvim_win_get_buf(0)
+        if vim.api.nvim_buf_get_option(buf, 'filetype') ~= 'dashboard' then
+          return
+        end
+
         local curline = api.nvim_win_get_cursor(0)[1]
         if curline < first_line + 1 then
           curline = bottom - 1


### PR DESCRIPTION
Opening netrw after opening dashboard on startup:

```
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
Error executing lua callback: ...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: attempt to index local 'curline_str' (a nil value)
stack traceback:
	...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:133: in function <...ckstart/lazy/dashboard-nvim/lua/dashboard/theme/doom.lua:119>
```