### PR TITLE
fix: accurately identify files within current working directory for MRU filtering

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -175,7 +175,7 @@ local function mru_list(config)
 
   if config.mru.cwd_only then
     local cwd = uv.cwd()
-    local sep = package.config:sub(1, 1) -- Get platform-specific directory separator
+    local sep = utils.is_win and '\\' or '/'
     local cwd_with_sep = cwd .. sep
     mlist = vim.tbl_filter(function(file)
       local file_dir = vim.fn.fnamemodify(file, ':p:h')

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -175,10 +175,12 @@ local function mru_list(config)
 
   if config.mru.cwd_only then
     local cwd = uv.cwd()
+    local sep = package.config:sub(1, 1) -- Get platform-specific directory separator
+    local cwd_with_sep = cwd .. sep
     mlist = vim.tbl_filter(function(file)
       local file_dir = vim.fn.fnamemodify(file, ':p:h')
       if file_dir and cwd then
-        return file_dir:find(cwd, 1, true) == 1
+        return file_dir:sub(1, #cwd_with_sep) == cwd_with_sep
       end
     end, mlist)
   end

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -178,7 +178,7 @@ local function mru_list(config)
     local sep = utils.is_win and '\\' or '/'
     local cwd_with_sep = cwd .. sep
     mlist = vim.tbl_filter(function(file)
-      local file_dir = vim.fn.fnamemodify(file, ':p:h')
+      local file_dir = vim.fn.fnamemodify(file, ':p:h') .. sep
       if file_dir and cwd then
         return file_dir:sub(1, #cwd_with_sep) == cwd_with_sep
       end


### PR DESCRIPTION

This pull request addresses an issue in the MRU (Most Recently Used) file filtering logic, where files outside the current working directory (cwd) could incorrectly be included. The previous implementation relied on a substring match, which caused files with similar directory prefixes to be incorrectly identified as being within the cwd.


For example, if the `cwd` is `/foo/bar` and a file is located at `/foo/barrrr/baz`, the previous implementation would incorrectly include `/foo/barrrr/baz` as being within `/foo/bar` due to a partial substring match.