### PR TITLE
fix(hyper): handle backslash and slash regardles of os in cwd

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -175,7 +175,7 @@ local function mru_list(config)
 
   if config.mru.cwd_only then
     local cwd = uv.cwd()
-    local sep = (utils.is_win and not vim.o.shellslash) and '\\' or '/'
+    local sep = '/'
     local cwd_with_sep = cwd .. sep
     mlist = vim.tbl_filter(function(file)
       local file_dir = vim.fn.fnamemodify(file, ':p:h') .. sep

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -174,13 +174,11 @@ local function mru_list(config)
   local mlist = utils.get_mru_list()
 
   if config.mru.cwd_only then
-    local cwd = uv.cwd()
-    local sep = '/'
-    local cwd_with_sep = cwd .. sep
+    local cwd_filtered = uv.cwd():gsub('[\\/]', '')
     mlist = vim.tbl_filter(function(file)
-      local file_dir = vim.fn.fnamemodify(file, ':p:h') .. sep
-      if file_dir and cwd then
-        return file_dir:sub(1, #cwd_with_sep) == cwd_with_sep
+      local file_dir_filtered = vim.fn.fnamemodify(file, ':p:h'):gsub('[\\/]', '')
+      if file_dir_filtered and cwd_filtered then
+        return file_dir_filtered:find(cwd_filtered, 1, true) == 1
       end
     end, mlist)
   end

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -175,7 +175,7 @@ local function mru_list(config)
 
   if config.mru.cwd_only then
     local cwd = uv.cwd()
-    local sep = utils.is_win and '\\' or '/'
+    local sep = (utils.is_win and not vim.o.shellslash) and '\\' or '/'
     local cwd_with_sep = cwd .. sep
     mlist = vim.tbl_filter(function(file)
       local file_dir = vim.fn.fnamemodify(file, ':p:h') .. sep

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -178,7 +178,7 @@ local function mru_list(config)
     mlist = vim.tbl_filter(function(file)
       local file_dir_filtered = vim.fn.fnamemodify(file, ':p:h'):gsub('[\\/]', '')
       if file_dir_filtered and cwd_filtered then
-        return file_dir_filtered:find(cwd_filtered, 1, true) == 1
+        return file_dir_filtered:sub(1, #cwd_filtered) == cwd_filtered
       end
     end, mlist)
   end

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -174,11 +174,14 @@ local function mru_list(config)
   local mlist = utils.get_mru_list()
 
   if config.mru.cwd_only then
-    local cwd_filtered = uv.cwd():gsub('[\\/]', '')
+    local cwd = uv.cwd()
+    -- get separator from the first file
+    local sep = mlist[1]:match('[\\/]')
+    local cwd_with_sep = cwd:gsub('[\\/]', sep) .. sep
     mlist = vim.tbl_filter(function(file)
-      local file_dir_filtered = vim.fn.fnamemodify(file, ':p:h'):gsub('[\\/]', '')
-      if file_dir_filtered and cwd_filtered then
-        return file_dir_filtered:sub(1, #cwd_filtered) == cwd_filtered
+      local file_dir = vim.fn.fnamemodify(file, ':p:h')
+      if file_dir and cwd_with_sep then
+        return file_dir:sub(1, #cwd_with_sep) == cwd_with_sep
       end
     end, mlist)
   end


### PR DESCRIPTION
## Issue

If a user has `vim.o.shellslash` enabled slash usage on windows can get a bit weird. `uv.cwd` returns `\` while the filepaths in mru will contain `/`.

The aim of this PR is to solve this issue by instead of defaulting to backslash on windows, get the separator from the first item of mru, and use that as separator in `cwd_with_sep`