### PR TITLE
Option for fixed/alphabetical `shortcut` ordering for `hyper` theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ use {
 theme = 'hyper' --  theme is doom and hyper default is hyper
 disable_move    --  default is false disable move keymap for hyper
 shortcut_type   --  shorcut type 'letter' or 'number'
+shuffle_letter  --  default is true, shortcut 'letter' will be randomize, set to false to have ordered letter.
 change_to_vcs_root -- default is false,for open file in hyper mru. it will change to the root of vcs
 config = {},    --  config used for theme
 hide = {

--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -36,6 +36,7 @@ local function default_options()
     theme = 'hyper',
     disable_move = false,
     shortcut_type = 'letter',
+    shuffle_letter = false,
     buffer_name = 'Dashboard',
     change_to_vcs_root = false,
     config = {
@@ -190,6 +191,7 @@ function db:load_theme(opts)
     winid = self.winid,
     confirm_key = opts.confirm_key or nil,
     shortcut_type = opts.shortcut_type,
+    shuffle_letter = opts.shuffle_letter,
     change_to_vcs_root = opts.change_to_vcs_root,
   })
 

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -235,7 +235,9 @@ local function letter_hotkey(config)
     end
   end
 
-  if shuffle then shuffle_table(unused_keys) end
+  if shuffle then
+    shuffle_table(unused_keys)
+  end
 
   local unused_uppercase_keys = {}
   -- A - Z
@@ -245,7 +247,9 @@ local function letter_hotkey(config)
     end
   end
 
-  if shuffle then shuffle_table(unused_uppercase_keys) end
+  if shuffle then
+    shuffle_table(unused_uppercase_keys)
+  end
 
   -- Push shuffled uppercase keys after the lowercase ones
   for _, key in pairs(unused_uppercase_keys) do

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -216,6 +216,7 @@ end
 local function letter_hotkey(config)
   -- Reserve j, k keys to move up and down.
   local list = { 106, 107 }
+  local shuffle = config.shuffle_letter
 
   for _, item in pairs(config.shortcut or {}) do
     if item.key then
@@ -234,7 +235,7 @@ local function letter_hotkey(config)
     end
   end
 
-  shuffle_table(unused_keys)
+  if shuffle then shuffle_table(unused_keys) end
 
   local unused_uppercase_keys = {}
   -- A - Z
@@ -244,7 +245,7 @@ local function letter_hotkey(config)
     end
   end
 
-  shuffle_table(unused_uppercase_keys)
+  if shuffle then shuffle_table(unused_uppercase_keys) end
 
   -- Push shuffled uppercase keys after the lowercase ones
   for _, key in pairs(unused_uppercase_keys) do


### PR DESCRIPTION
I for one always hate the randomize `shortcut`. It breaks my workflow to have to read which key to press.

So, this PR add option `shuffle_letter` option to `hyper` theme so we can have fixed/ordered shortcut.

Set `shuffle_letter = false` in hyper `config` for fixed/ordered `shortcut` 

Closes #374, closes #439 