### PR TITLE
feat: add items to center on condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ config = {
       key_hl = 'group',
       key_format = ' [%s]', -- `%s` will be substituted with value of `key`
       action = '',
+      cond = nil, -- if a condition is given, show item if condition is true
     },
   },
   footer = {},
@@ -218,6 +219,13 @@ db.setup({
         keymap = 'SPC f d',
         key_format = ' %s', -- remove default surrounding `[]`
         action = 'lua print(3)'
+      },
+      {
+        icon = " ",
+        desc = " git",
+        key = "g"
+        action = "Neogit",
+        cond = cwd_is_git_repo() -- pass in a boolean value or define a custom function and call it
       },
     },
     footer = {}  --your footer

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -35,10 +35,12 @@ local function generate_center(config)
       line = line .. (' '):rep(#item.keymap)
     end
 
-    table.insert(lines, line)
-    table.insert(lines, '')
-    table.insert(counts, count)
-    table.insert(counts, 0)
+    if item.cond == nil or item.cond then
+      table.insert(lines, line)
+      table.insert(lines, '')
+      table.insert(counts, count)
+      table.insert(counts, 0)
+    end
   end
 
   lines = utils.element_align(lines)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -9,7 +9,8 @@ local function generate_center(config)
     }
 
   local counts = {}
-  for _, item in pairs(center) do
+  local to_remove = {}
+  for i, item in pairs(center) do
     if item.cond == nil or item.cond then
       local count = item.keymap and #item.keymap or 0
       local line = (item.icon or '') .. item.desc
@@ -40,7 +41,13 @@ local function generate_center(config)
       table.insert(lines, '')
       table.insert(counts, count)
       table.insert(counts, 0)
+    else
+      table.insert(to_remove, i)
     end
+  end
+
+  for i = #to_remove, 1, -1 do
+    table.remove(center, to_remove[i])
   end
 
   lines = utils.element_align(lines)

--- a/lua/dashboard/theme/doom.lua
+++ b/lua/dashboard/theme/doom.lua
@@ -10,32 +10,32 @@ local function generate_center(config)
 
   local counts = {}
   for _, item in pairs(center) do
-    local count = item.keymap and #item.keymap or 0
-    local line = (item.icon or '') .. item.desc
-
-    if item.key then
-      line = line .. (' '):rep(#item.key + 4)
-      count = count + #item.key + 3
-      local desc = 'Dashboard-action: ' .. item.desc:gsub('^%s+', '')
-      keymap.set('n', item.key, function()
-        if type(item.action) == 'string' then
-          local dump = loadstring(item.action)
-          if not dump then
-            vim.cmd(item.action)
-          else
-            dump()
-          end
-        elseif type(item.action) == 'function' then
-          item.action()
-        end
-      end, { buffer = config.bufnr, nowait = true, silent = true, desc = desc })
-    end
-
-    if item.keymap then
-      line = line .. (' '):rep(#item.keymap)
-    end
-
     if item.cond == nil or item.cond then
+      local count = item.keymap and #item.keymap or 0
+      local line = (item.icon or '') .. item.desc
+
+      if item.key then
+        line = line .. (' '):rep(#item.key + 4)
+        count = count + #item.key + 3
+        local desc = 'Dashboard-action: ' .. item.desc:gsub('^%s+', '')
+        keymap.set('n', item.key, function()
+          if type(item.action) == 'string' then
+            local dump = loadstring(item.action)
+            if not dump then
+              vim.cmd(item.action)
+            else
+              dump()
+            end
+          elseif type(item.action) == 'function' then
+            item.action()
+          end
+        end, { buffer = config.bufnr, nowait = true, silent = true, desc = desc })
+      end
+
+      if item.keymap then
+        line = line .. (' '):rep(#item.keymap)
+      end
+
       table.insert(lines, line)
       table.insert(lines, '')
       table.insert(counts, count)


### PR DESCRIPTION
Here is a simple addition to the doom theme that allows items in the center to be conditionally shown. My main use case for this is for sessions and git. For example,

```lua
center = {
  -- items removed
  { 
    action = "Neogit", 
    desc = " git",
    icon = " ", 
    key = "G", 
    cond = require("cmill.core.util").is_git_repo() -- only show if cwd is git repo
  }, { 
    action = "SessionManager load_current_dir_session", 
    desc = " restore session", 
    icon = " ", 
    key = "s", 
    cond = require("session_manager").current_dir_session_exists()  -- only show if session for cwd exists
  },
  -- items removed
}
```