### PR TITLE
Fix bug where plugin would crash if icon was empty

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -354,6 +354,9 @@ local function gen_center(plist, config)
 
   local start_col = plist[plist_len + 2]:find('[^%s]') - 1
   local _, scol = plist[2]:find('%S')
+  if scol == nil then
+    scol = 0
+  end
 
   local hotkey = gen_hotkey(config)
 


### PR DESCRIPTION
On hyper theme's mru, fix a bug where the plugin would crash if config.project.icon was a string with only whitespace characters