### PR TITLE
Supports spaces in path for projects

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -303,12 +303,17 @@ local function map_key(config, key, content)
       end
       text = text:sub(scol)
       path = text:sub(1, text:find('%w(%s+)$'))
+      if string.find(path, '[%]%[]') ~= nil then
+        vim.notify('Brackets in path names are not currently supported', vim.log.levels.ERROR)
+        return
+      end
       path = vim.fs.normalize(path)
     end
 
     if path == nil then
       vim.cmd('enew')
     elseif vim.fn.isdirectory(path) == 1 then
+      path = vim.fn.fnameescape(path)
       vim.cmd('lcd ' .. path)
       if type(config.project.action) == 'function' then
         config.project.action(path)
@@ -321,7 +326,7 @@ local function map_key(config, key, content)
         end
       end
     else
-      vim.cmd('edit ' .. vim.fn.fnameescape(path))
+      vim.cmd('edit ' .. path)
       local root = utils.get_vcs_root()
       if not config.change_to_vcs_root then
         return


### PR DESCRIPTION
Fixes #453.

Adds ability to  support recent projects that have a space in the path. Simple filename escaping.

Was going to add support for ``[`` and ``]`` but once I did, Telescope started throwing errors. Either way brackets in path names are bad practice. Therefore we throw an error stating its not supported if it is found.