### PR TITLE
Improve lazy.nvim installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@
 {
   'nvimdev/dashboard-nvim',
   event = 'VimEnter',
-  config = function()
-    require('dashboard').setup {
-      -- config
-    }
-  end,
+  opts = {
+    -- config
+  },
   dependencies = { {'nvim-tree/nvim-web-devicons'}}
 }
 ```


### PR DESCRIPTION
Per the [Lazy.nvim plugin spec](https://lazy.folke.io/spec#spec-setup) the options should be specified in `opts` and the main module for `setup` should be specified explicitly or autodetected by lazy.nvim.