### PR TITLE
feat(utils): Add a helper to handle vim.validate for tables

### DIFF
--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -2,7 +2,7 @@ local uv = vim.loop
 local utils = {}
 
 utils.is_win = uv.os_uname().version:match('Windows')
-local is_nvim_11_or_newer = vim.fn.has 'nvim-0.11' == 1
+local is_nvim_11_or_newer = vim.fn.has ('nvim-0.11') == 1
 
 function utils.path_join(...)
   local path_sep = utils.is_win and '\\' or '/'

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -35,6 +35,7 @@ function utils.get_max_len(contents)
   return cells[#cells]
 end
 
+-- draw the graphics into the screen center
 function utils.center_align(tbl)
   vim.validate('tbl', tbl, 'table')
   local function fill_sizes(lines)
@@ -95,6 +96,7 @@ function utils.disable_move_key(bufnr)
   end, keys)
 end
 
+-- return the most recently files list
 function utils.get_mru_list()
   local mru = {}
   for _, file in pairs(vim.v.oldfiles or {}) do
@@ -107,8 +109,10 @@ end
 
 function utils.get_package_manager_stats()
   local package_manager_stats = { name = '', count = 0, loaded = 0, time = 0 }
+  ---@diagnostic disable-next-line: undefined-global
   if packer_plugins then
     package_manager_stats.name = 'packer'
+    ---@diagnostic disable-next-line: undefined-global
     package_manager_stats.count = #vim.tbl_keys(packer_plugins)
   end
   local status, lazy = pcall(require, 'lazy')
@@ -122,6 +126,7 @@ function utils.get_package_manager_stats()
   return package_manager_stats
 end
 
+--- generate an empty table by length
 function utils.generate_empty_table(length)
   local empty_tbl = {}
   if length == 0 then
@@ -181,7 +186,7 @@ function utils.add_update_footer_command(bufnr, footer)
     vim.bo[bufnr].modifiable = false
     vim.bo[bufnr].modified = false
 
-    last_footer_size = #args.fargs
+    last_footer_size = #args.fargs -- For future calculation of size
   end, { nargs = '*' })
 end
 

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -2,7 +2,7 @@ local uv = vim.loop
 local utils = {}
 
 utils.is_win = uv.os_uname().version:match('Windows')
-local is_nvim_11_or_newer = vim.fn.has ('nvim-0.11') == 1
+local is_nvim_11_or_newer = vim.fn.has('nvim-0.11') == 1
 
 function utils.path_join(...)
   local path_sep = utils.is_win and '\\' or '/'

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -26,9 +26,7 @@ function utils.element_align(tbl)
 end
 
 function utils.get_max_len(contents)
-  vim.validate({
-    contents = { contents, 't' },
-  })
+  assert(type(contents) == 'table', 'contents must be a table')
   local cells = {}
   for _, v in pairs(contents) do
     table.insert(cells, vim.api.nvim_strwidth(v))
@@ -37,11 +35,8 @@ function utils.get_max_len(contents)
   return cells[#cells]
 end
 
--- draw the graphics into the screen center
 function utils.center_align(tbl)
-  vim.validate({
-    tbl = { tbl, 'table' },
-  })
+  assert(type(tbl) == 'table', 'tbl must be a table')
   local function fill_sizes(lines)
     local fills = {}
     for _, line in pairs(lines) do
@@ -100,7 +95,6 @@ function utils.disable_move_key(bufnr)
   end, keys)
 end
 
---- return the most recently files list
 function utils.get_mru_list()
   local mru = {}
   for _, file in pairs(vim.v.oldfiles or {}) do
@@ -113,29 +107,26 @@ end
 
 function utils.get_package_manager_stats()
   local package_manager_stats = { name = '', count = 0, loaded = 0, time = 0 }
-  ---@diagnostic disable-next-line: undefined-global
   if packer_plugins then
     package_manager_stats.name = 'packer'
-    ---@diagnostic disable-next-line: undefined-global
     package_manager_stats.count = #vim.tbl_keys(packer_plugins)
   end
   local status, lazy = pcall(require, 'lazy')
   if status then
     package_manager_stats.name = 'lazy'
-    package_manager_stats.loaded = lazy.stats().loaded
-    package_manager_stats.count = lazy.stats().count
-    package_manager_stats.time = lazy.stats().startuptime
+    local stats = lazy.stats()
+    package_manager_stats.loaded = stats.loaded
+    package_manager_stats.count = stats.count
+    package_manager_stats.time = stats.startuptime
   end
   return package_manager_stats
 end
 
---- generate an empty table by length
 function utils.generate_empty_table(length)
   local empty_tbl = {}
   if length == 0 then
     return empty_tbl
   end
-
   for _ = 1, length do
     table.insert(empty_tbl, '')
   end
@@ -168,7 +159,7 @@ end
 function utils.buf_is_empty(bufnr)
   bufnr = bufnr or 0
   return vim.api.nvim_buf_line_count(0) == 1
-    and vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == ''
+      and vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == ''
 end
 
 local last_footer_size = nil
@@ -190,7 +181,7 @@ function utils.add_update_footer_command(bufnr, footer)
     vim.bo[bufnr].modifiable = false
     vim.bo[bufnr].modified = false
 
-    last_footer_size = #args.fargs -- For future calculation of size
+    last_footer_size = #args.fargs
   end, { nargs = '*' })
 end
 

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -26,7 +26,7 @@ function utils.element_align(tbl)
 end
 
 function utils.get_max_len(contents)
-  assert(type(contents) == 'table', 'contents must be a table')
+  vim.validate('contents', contents, 'table')
   local cells = {}
   for _, v in pairs(contents) do
     table.insert(cells, vim.api.nvim_strwidth(v))
@@ -36,7 +36,7 @@ function utils.get_max_len(contents)
 end
 
 function utils.center_align(tbl)
-  assert(type(tbl) == 'table', 'tbl must be a table')
+  vim.validate('tbl', tbl, 'table')
   local function fill_sizes(lines)
     local fills = {}
     for _, line in pairs(lines) do

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -2,7 +2,7 @@ local uv = vim.loop
 local utils = {}
 
 utils.is_win = uv.os_uname().version:match('Windows')
-local is_nvim_11_or_newer = vim.version().minor >= 11 -- check nvim minor ver
+local is_nvim_11_or_newer = vim.fn.has 'nvim-0.11' == 1
 
 function utils.path_join(...)
   local path_sep = utils.is_win and '\\' or '/'

--- a/lua/dashboard/utils.lua
+++ b/lua/dashboard/utils.lua
@@ -2,10 +2,20 @@ local uv = vim.loop
 local utils = {}
 
 utils.is_win = uv.os_uname().version:match('Windows')
+local is_nvim_11_or_newer = vim.version().minor >= 11 -- check nvim minor ver
 
 function utils.path_join(...)
   local path_sep = utils.is_win and '\\' or '/'
   return table.concat({ ... }, path_sep)
+end
+
+-- dynamically use correct validate form method
+local function validate_table(name, value)
+  if is_nvim_11_or_newer then
+    vim.validate(name, value, 'table')
+  else
+    vim.validate({ [name] = { value, 't' } })
+  end
 end
 
 function utils.element_align(tbl)
@@ -26,7 +36,7 @@ function utils.element_align(tbl)
 end
 
 function utils.get_max_len(contents)
-  vim.validate('contents', contents, 'table')
+  validate_table('contents', contents)
   local cells = {}
   for _, v in pairs(contents) do
     table.insert(cells, vim.api.nvim_strwidth(v))
@@ -37,7 +47,7 @@ end
 
 -- draw the graphics into the screen center
 function utils.center_align(tbl)
-  vim.validate('tbl', tbl, 'table')
+  validate_table('tbl', tbl)
   local function fill_sizes(lines)
     local fills = {}
     for _, line in pairs(lines) do


### PR DESCRIPTION
## New helper function to handle vim.validate dynamically for tables

* This function will dynamically use the correct validate method based on the neovim version.
* This addresses the issue reported here which makes the newer validate method breaks the plugin on neovim versions < 0.11:  [https://github.com/LazyVim/LazyVim/issues/6000](https://github.com/LazyVim/LazyVim/issues/6000)

NOTE: I only tested this on my machine which has neovim version 0.11. But hopefully should work on older neovim versions now (as long as the `vim.version().minor` returns the expected output).

