### PR TITLE
feat(hyper): support multiple confirm_keys and exclude them from letter_list

### DIFF
--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -239,6 +239,12 @@ local function letter_hotkey(config)
     end
   end
 
+  local confirm_keys = type(config.confirm_key) == 'table' and config.confirm_key
+    or { config.confirm_key }
+  for _, key in ipairs(confirm_keys) do
+    table.insert(used_keys, key:byte())
+  end
+
   math.randomseed(os.time())
 
   -- Create key table, fill it with unused characters.

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -538,7 +538,11 @@ local function theme_instance(config)
     load_packages(config)
     gen_center(plist, config)
     gen_footer(config)
-    map_key(config, config.confirm_key or '<CR>')
+    local confirm_keys = type(config.confirm_key) == 'table' and config.confirm_key
+      or { config.confirm_key or '<CR>' }
+    for _, key in ipairs(confirm_keys) do
+      map_key(config, key)
+    end
     require('dashboard.events').register_lsp_root(config.path)
     local size = math.floor(vim.o.lines / 2)
       - math.ceil(api.nvim_buf_line_count(config.bufnr) / 2)


### PR DESCRIPTION
In the Hyper theme, this PR updates the `confirm_key` option to accept an array of strings instead of just a single string.  
It also removes any keys specified in `confirm_key` from the `letter_list`.

```lua
-- in options
confirm_key = 'o' -- or { 'o', '<CR>' }
```