### PR TITLE
fix: correctly handle stdin

### DIFF
--- a/plugin/dashboard.lua
+++ b/plugin/dashboard.lua
@@ -2,10 +2,15 @@
 
 local g = vim.api.nvim_create_augroup('dashboard', { clear = true })
 
-vim.api.nvim_create_autocmd('StdinReadPre', {
+vim.api.nvim_create_autocmd('VimEnter', {
   group = g,
   callback = function()
-    vim.g.read_from_stdin = 1
+    for _, v in pairs(vim.v.argv) do
+      if v == "-" then
+        vim.g.read_from_stdin = 1
+        break
+      end
+    end
   end,
 })
 


### PR DESCRIPTION
fixes https://github.com/nvimdev/dashboard-nvim/issues/475

The `StdinReadPre` autocmd doesn't seem to set the `vim.g.read_from_stdin` variable, which means when you run something like the following:

```shell
echo "hello world!" | nvim -
```

The dashboard will override initial buffer and the `hello world!` will be lost.

I've changed this autocmd to `VimEnter` and now it will check for the `-` arguement in the arguments list to determine if nvim is reading from stdin.