### PR TITLE
feat(hyper): display shortcuts on the left side

### DIFF
--- a/lua/dashboard/init.lua
+++ b/lua/dashboard/init.lua
@@ -198,6 +198,7 @@ function db:load_theme(opts)
     bufnr = self.bufnr,
     winid = self.winid,
     confirm_key = opts.confirm_key or nil,
+    shortcuts_left_side = opts.shortcuts_left_side,
     shortcut_type = opts.shortcut_type,
     shuffle_letter = opts.shuffle_letter,
     letter_list = opts.letter_list,

--- a/lua/dashboard/theme/hyper.lua
+++ b/lua/dashboard/theme/hyper.lua
@@ -138,9 +138,10 @@ local function project_list(config, callback)
     if list then
       list = vim.list_slice(list, #list - config.project.limit)
     end
+    local blank_size = config.shortcuts_left_side and 4 or 3
     for _, dir in ipairs(list or {}) do
       dir = dir:gsub(vim.env.HOME, '~')
-      table.insert(res, (' '):rep(3) .. ' ' .. dir)
+      table.insert(res, (' '):rep(blank_size) .. ' ' .. dir)
     end
 
     if #res == 0 then
@@ -200,6 +201,7 @@ local function mru_list(config)
     end, mlist)
   end
 
+  local blank_size = config.shortcuts_left_side and 4 or 3
   for _, file in pairs(vim.list_slice(mlist, 1, config.mru.limit)) do
     local filename = vim.fn.fnamemodify(file, ':t')
     local icon, group = utils.get_icon(filename)
@@ -211,7 +213,7 @@ local function mru_list(config)
     end
     file = icon .. ' ' .. file
     table.insert(groups, { #icon, group })
-    table.insert(list, (' '):rep(3) .. file)
+    table.insert(list, (' '):rep(blank_size) .. file)
   end
 
   if #list == 1 then
@@ -414,10 +416,17 @@ local function gen_center(plist, config)
     local text = api.nvim_buf_get_lines(config.bufnr, first_line + i - 1, first_line + i, false)[1]
     if text and text:find('%w') and not text:find('empty') then
       local key = tostring(hotkey())
-      api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i - 1, 0, {
-        virt_text = { { key, 'DashboardShortCut' } },
-        virt_text_pos = 'eol',
-      })
+      if config.shortcuts_left_side then
+        api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i - 1, start_col - 1, {
+          virt_text = { { key, 'DashboardShortCut' } },
+          virt_text_pos = 'inline',
+        })
+      else
+        api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i - 1, 0, {
+          virt_text = { { key, 'DashboardShortCut' } },
+          virt_text_pos = 'eol',
+        })
+      end
       map_key(config, key, text)
     end
   end
@@ -464,10 +473,17 @@ local function gen_center(plist, config)
     )[1]
     if text and text:find('%w') then
       local key = tostring(hotkey())
-      api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i + plist_len, 0, {
-        virt_text = { { key, 'DashboardShortCut' } },
-        virt_text_pos = 'eol',
-      })
+      if config.shortcuts_left_side then
+        api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i + plist_len, start_col - 1, {
+          virt_text = { { key, 'DashboardShortCut' } },
+          virt_text_pos = 'inline',
+        })
+      else
+        api.nvim_buf_set_extmark(config.bufnr, ns, first_line + i + plist_len, 0, {
+          virt_text = { { key, 'DashboardShortCut' } },
+          virt_text_pos = 'eol',
+        })
+      end
       map_key(config, key, text)
     end
   end

--- a/plugin/dashboard.lua
+++ b/plugin/dashboard.lua
@@ -6,7 +6,7 @@ vim.api.nvim_create_autocmd('VimEnter', {
   group = g,
   callback = function()
     for _, v in pairs(vim.v.argv) do
-      if v == "-" then
+      if v == '-' then
         vim.g.read_from_stdin = 1
         break
       end


### PR DESCRIPTION
Allow displaying shortcuts on the left side in the hyper theme.

```lua
opts = {
  ...
  shortcuts_left_side = true, -- if true, display on the left side
  ...
}
```

<img width="691" alt="SCR-20250603-dguf" src="https://github.com/user-attachments/assets/3b11e622-e919-4017-acaf-98f761b78cef" />

